### PR TITLE
Fixes #9 and #10

### DIFF
--- a/src/BeautifulComments/BCBeautifulCommentsSmokeTest.class.st
+++ b/src/BeautifulComments/BCBeautifulCommentsSmokeTest.class.st
@@ -8,7 +8,7 @@ Class {
 BCBeautifulCommentsSmokeTest >> testRenderDoesNotRaiseError [
 
 	self 
-		shouldnt: [ MicRichTextComposer 
+		shouldnt: [ BeautifulComments  
 							renderComment: ClyRichTextClassCommentEditorToolMorph comment 
 							of: ClyRichTextClassCommentEditorToolMorph ]
 		raise: Error

--- a/src/BeautifulComments/BeautifulComments.class.st
+++ b/src/BeautifulComments/BeautifulComments.class.st
@@ -1,0 +1,78 @@
+"
+I hold preferences for the BeautifulComments (in class variables and methods on my class side).
+
+## Settings
+- In particular one can disable rich text rendering (showing the raw comments of the class), which is done in the settings browser `rendering`, or through my class side method `render: aBoolean`.
+
+- As per fall of 2021 microdown and microdown support in Pharo is still in active development. Errors can occour! It is possible to set the comment to be robust to errors in the microdown in class comments. This is controlled by the `capture errors`, or through the class side method: 'captureErrors: aBoolean`.
+"
+Class {
+	#name : #BeautifulComments,
+	#superclass : #Object,
+	#classVars : [
+		'CaptureErrors',
+		'Rendering'
+	],
+	#category : #'BeautifulComments-Core'
+}
+
+{ #category : #settings }
+BeautifulComments class >> captureErrors [ 
+	^ CaptureErrors ifNil: [ false ]
+]
+
+{ #category : #settings }
+BeautifulComments class >> captureErrors: aBoolean [ 
+	CaptureErrors := aBoolean
+]
+
+{ #category : #settings }
+BeautifulComments class >> preferencesSettingsOn: aBuilder [
+	<to_be_done_systemsettings>
+	(aBuilder group: #comments)
+		label: 'Comment rendering';  
+		parent: #appearance;
+		description: 'All settings concerned with the control of nice comment rendering';
+		with: [. 
+			(aBuilder setting: #notRendering)
+				label: 'To disable richtext rendering';
+				default: false;
+				target: self;
+				description: 'Comments are by default rendered via Pillar in Richtext. When this setting is on, they are rendered as plain text (showing their Microdown definitions).'. 
+			(aBuilder setting: #captureErrors)
+				label: 'To disable rendering error capture';
+				default: true;
+				target: self;
+				description: 'By default if there is an error during the rendering of the comments, various errors are trapped. If you want to get such errors to debug the system, you should turn off this settings.'. 
+			
+			]
+]
+
+{ #category : #rendering }
+BeautifulComments class >> render: aString [ 
+	"Render a string, in case of error, just return it."
+	
+	self rendering 	
+		ifFalse: [ ^ aString ].
+	self captureErrors 
+		ifFalse: [ ^ MicRichTextComposer microdownAsRichText: aString ].
+	^ [ MicRichTextComposer microdownAsRichText: aString ] 
+			on: Error
+			do: [ aString  ]
+]
+
+{ #category : #rendering }
+BeautifulComments class >> renderComment: aString of: aClassOrPackage [ 
+	"Return aString as part of the templated class comment, when rendering is on.
+	Else aString."
+	
+	| builder |
+	builder := MicroDownParser builder.
+	aClassOrPackage buildMicroDownUsing: builder withComment: aString.
+	^ self render: builder contents
+]
+
+{ #category : #settings }
+BeautifulComments class >> rendering [
+	^ Rendering ifNil: [ true ]
+]

--- a/src/BeautifulComments/BeautifulComments.class.st
+++ b/src/BeautifulComments/BeautifulComments.class.st
@@ -55,8 +55,8 @@ BeautifulComments class >> render: aString [
 	self rendering 	
 		ifFalse: [ ^ aString ].
 	self captureErrors 
-		ifFalse: [ ^ MicRichTextComposer microdownAsRichText: aString ].
-	^ [ MicRichTextComposer microdownAsRichText: aString ] 
+		ifFalse: [ ^ Microdown asRichText: aString ].
+	^ [ Microdown asRichText: aString ] 
 			on: Error
 			do: [ aString  ]
 ]

--- a/src/BeautifulComments/BeautifulComments.class.st
+++ b/src/BeautifulComments/BeautifulComments.class.st
@@ -28,22 +28,22 @@ BeautifulComments class >> captureErrors: aBoolean [
 
 { #category : #settings }
 BeautifulComments class >> preferencesSettingsOn: aBuilder [
-	<to_be_done_systemsettings>
+	<systemsettings>
 	(aBuilder group: #comments)
 		label: 'Comment rendering';  
 		parent: #appearance;
 		description: 'All settings concerned with the control of nice comment rendering';
 		with: [. 
-			(aBuilder setting: #notRendering)
-				label: 'To disable richtext rendering';
-				default: false;
-				target: self;
-				description: 'Comments are by default rendered via Pillar in Richtext. When this setting is on, they are rendered as plain text (showing their Microdown definitions).'. 
-			(aBuilder setting: #captureErrors)
-				label: 'To disable rendering error capture';
+			(aBuilder setting: #rendering)
+				label: 'Enable richtext comments';
 				default: true;
 				target: self;
-				description: 'By default if there is an error during the rendering of the comments, various errors are trapped. If you want to get such errors to debug the system, you should turn off this settings.'. 
+				description: 'Comments are by default rendered via microdown. When this setting is on, they are rendered as plain string (showing their Microdown definitions).'. 
+			(aBuilder setting: #captureErrors)
+				label: 'Enable rendering error capture';
+				default: true;
+				target: self;
+				description: 'By default microdown errors in comment text will not cause debugger to open. Turn this of to get debugger to open on errors'. 
 			
 			]
 ]
@@ -75,4 +75,9 @@ BeautifulComments class >> renderComment: aString of: aClassOrPackage [
 { #category : #settings }
 BeautifulComments class >> rendering [
 	^ Rendering ifNil: [ true ]
+]
+
+{ #category : #rendering }
+BeautifulComments class >> rendering: aBoolean [
+	Rendering := aBoolean
 ]

--- a/src/BeautifulComments/ClyEditCommentSwitchMorph.class.st
+++ b/src/BeautifulComments/ClyEditCommentSwitchMorph.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'checkbox'
 	],
-	#category : #'BeautifulComments-Morph'
+	#category : #'BeautifulComments-Core'
 }
 
 { #category : #building }

--- a/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'isRendering'
 	],
-	#category : #'BeautifulComments-UI'
+	#category : #'BeautifulComments-Core'
 }
 
 { #category : #activation }
@@ -30,7 +30,7 @@ ClyPackageRichTextCommentEditorToolMorph >> asRenderedText: comment [
 	asText turns it into a Text, and asString into a string, which is what we expect. 
 	If we have a real source code, asText asString is dummy and does not fail."
 
-	^ MicRichTextComposer renderComment: comment asText asString of: self editingPackage 
+	^ self renderComment: comment asText asString of: self editingPackage 
 ]
 
 { #category : #initialization }

--- a/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
@@ -10,7 +10,7 @@ Class {
 	#instVars : [
 		'isRendering'
 	],
-	#category : #'BeautifulComments-UI'
+	#category : #'BeautifulComments-Core'
 }
 
 { #category : #activation }
@@ -29,7 +29,7 @@ ClyRichTextClassCommentEditorToolMorph >> asRenderedText: comment [
 	asText turns it into a Text, and asString into a string, which is what we expect. 
 	If we have a real source code, asText asString is dummy and does not fail."
 
-	^ MicRichTextComposer renderComment: comment asText asString of: self editingClass 
+	^ self renderComment: comment asText asString of: self editingClass 
 ]
 
 { #category : #rendering }

--- a/src/BeautifulComments/ClySyntaxHelpMorph.class.st
+++ b/src/BeautifulComments/ClySyntaxHelpMorph.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'button'
 	],
-	#category : #'BeautifulComments-Morph'
+	#category : #'BeautifulComments-Core'
 }
 
 { #category : #building }

--- a/src/BeautifulComments/TClyRichTextCommentEditorPaneMorph.trait.st
+++ b/src/BeautifulComments/TClyRichTextCommentEditorPaneMorph.trait.st
@@ -6,7 +6,7 @@ Trait {
 	#instVars : [
 		'isRendering'
 	],
-	#category : #'BeautifulComments-UI'
+	#category : #'BeautifulComments-Core'
 }
 
 { #category : #'trait rendering' }
@@ -15,6 +15,11 @@ TClyRichTextCommentEditorPaneMorph >> buildTextMorph [
 	self setBackgroundColor: self renderColor.
 	self bindKeyCombination: $r command toAction: [ self toggleMode ].
 	self disable 
+]
+
+{ #category : #'class initialization' }
+TClyRichTextCommentEditorPaneMorph >> captureErrors [ 
+	^ BeautifulComments captureErrors 
 ]
 
 { #category : #'trait rendering' }
@@ -47,7 +52,7 @@ TClyRichTextCommentEditorPaneMorph >> initializePaneTrait [
 
 { #category : #'trait rendering' }
 TClyRichTextCommentEditorPaneMorph >> isRendering [
-	^ isRendering
+	^ BeautifulComments rendering
 ]
 
 { #category : #'trait rendering' }
@@ -57,6 +62,13 @@ TClyRichTextCommentEditorPaneMorph >> renderColor [
 	^ bgColor lightness < 0.5
 		ifTrue: [ bgColor + (Color r: 0.0 g: 0.04 b:0.08 )]
 		ifFalse: [ bgColor darker ]
+]
+
+{ #category : #rendering }
+TClyRichTextCommentEditorPaneMorph >> renderComment: aString of: aClassOrPackage [ 
+	"The actual implementation is moved to BeautifulComments - basically to allow Testing"
+	
+	^ BeautifulComments renderComment: aString of: aClassOrPackage
 ]
 
 { #category : #'trait rendering' }


### PR DESCRIPTION
Beautiful comments will now work again. This PR fixes both #9 and #10.
A new class was introduced `BeautifulComments` which keep the settings variables and the preference definition.
In addition, it holds some render logic which is controlled by those variables, and which allow the smoke test to run.