### PR TITLE
Fixes #8. Added two tests

### DIFF
--- a/src/BeautifulComments/BCBeautifulCommentsSmokeTest.class.st
+++ b/src/BeautifulComments/BCBeautifulCommentsSmokeTest.class.st
@@ -13,3 +13,30 @@ BCBeautifulCommentsSmokeTest >> testRenderDoesNotRaiseError [
 							of: ClyRichTextClassCommentEditorToolMorph ]
 		raise: Error
 ]
+
+{ #category : #tests }
+BCBeautifulCommentsSmokeTest >> testSmokeSignal [
+	BeautifulComments captureErrors: true.
+	Smalltalk globals allClasses do: [ :cl |
+			BeautifulComments  
+							renderComment: cl comment 
+							of: cl
+		
+		 ]	
+]
+
+{ #category : #tests }
+BCBeautifulCommentsSmokeTest >> testSmokeSignalAndChoke [
+	| difficultClasses |
+	"this test disables error handling and tries to render all class comments in the system"
+	"Really, it is a test of the robustness of Microdown parsing and rendering"
+	self skip.
+	BeautifulComments captureErrors: false.
+	difficultClasses := OrderedCollection new.
+	Smalltalk globals allClasses do: [ :cl |
+			[BeautifulComments renderComment: cl comment of: cl]
+			on: Exception 
+			do: [ difficultClasses add: cl ]
+		 ].
+	self assert: difficultClasses isEmpty
+]


### PR DESCRIPTION
Added a test to show that the errorhandling of BeautifulComments is robust (do not break) for any class in the system.

Also added a test that demonstrates that without that error handling, there are a number of class comments which cause Microdown to fail - perhaps this test really belong in Microdown after all.