### PR TITLE
Fixes #31. Test Failing on Pharo CI: BCBeautifulCommentsSettingsTest>>testNoErrorCatch

### DIFF
--- a/src/BeautifulComments/BCFailingOnPurposeForTestBlock.class.st
+++ b/src/BeautifulComments/BCFailingOnPurposeForTestBlock.class.st
@@ -1,7 +1,7 @@
 "
 I am a comment which cannot be rendered correctly - I use a dedicated error to fail. 
 Toggle Edit/View comment to see how this is done.
-?{failingOnPurpose}?
+{!failingOnPurpose!}
 "
 Class {
 	#name : #BCFailingOnPurposeForTestBlock,


### PR DESCRIPTION
The syntax for Annotations were changed, and a class comment needed to be updated (as that specific class comment is part of a test using annotations)