### PR TITLE
Remove ClyComment*Editor hacks

### DIFF
--- a/src/BeautifulComments/ClyClassCommentEditorToolMorph.extension.st
+++ b/src/BeautifulComments/ClyClassCommentEditorToolMorph.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #ClyClassCommentEditorToolMorph }
-
-{ #category : #'*BeautifulComments' }
-ClyClassCommentEditorToolMorph class >> new [
-	"A hack to swap in the RichText versions of the tools. "
-	^ ClyRichTextClassCommentEditorToolMorph basicNew initialize
-]

--- a/src/BeautifulComments/ClyPackageCommentEditorToolMorph.extension.st
+++ b/src/BeautifulComments/ClyPackageCommentEditorToolMorph.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #ClyPackageCommentEditorToolMorph }
-
-{ #category : #'*BeautifulComments' }
-ClyPackageCommentEditorToolMorph class >> new [
-	"A hack to swap in the RichText versions of the tools. "
-	^ ClyPackageRichTextCommentEditorToolMorph  basicNew initialize
-]

--- a/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
@@ -143,6 +143,17 @@ ClyPackageRichTextCommentEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 	^editingPackage = anotherBrowserTool editingPackage
 ]
 
+{ #category : #testing }
+ClyPackageRichTextCommentEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
+	
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	^ aClyFullBrowserContext isPackageSelected
+		ifTrue: [ self editingPackage = aClyFullBrowserContext lastSelectedPackage ]
+		ifFalse: [ false ]
+]
+
 { #category : #accessing }
 ClyPackageRichTextCommentEditorToolMorph >> packageCommentBlank [
 

--- a/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
@@ -41,6 +41,17 @@ ClyPackageRichTextCommentEditorToolMorph >> asRenderedText: comment [
 	^ self renderComment: comment asText asString of: self editingPackage 
 ]
 
+{ #category : #accessing }
+ClyPackageRichTextCommentEditorToolMorph >> basicEditingText [
+
+	^ editingPackage packageManifestOrNil 
+		ifNil: [ self packageCommentBlank ]
+		ifNotNil: [ :manifest | 
+			manifest hasComment 
+				ifTrue: [ manifest comment ] 
+				ifFalse: [ self packageCommentBlank ] ]
+]
+
 { #category : #initialization }
 ClyPackageRichTextCommentEditorToolMorph >> disable [
 	textMorph enabled: false

--- a/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyPackageRichTextCommentEditorToolMorph.class.st
@@ -5,23 +5,48 @@ I am a replacement for the _package comments_ tool.
 "
 Class {
 	#name : #ClyPackageRichTextCommentEditorToolMorph,
-	#superclass : #ClyPackageCommentEditorToolMorph,
+	#superclass : #ClyTextEditorToolMorph,
 	#traits : 'TClyRichTextCommentEditorPaneMorph',
 	#classTraits : 'TClyRichTextCommentEditorPaneMorph classTrait',
 	#instVars : [
+		'editingPackage',
 		'isRendering'
 	],
 	#category : #'BeautifulComments-Core'
 }
 
 { #category : #activation }
-ClyPackageRichTextCommentEditorToolMorph class >> browserTabActivation [  
-	"Do nothing - part of a hack for overriding the class package tool in Calypso"
+ClyPackageRichTextCommentEditorToolMorph class >> browserTabActivation [
+	"This declaration specifies that in any browser when packages are selected, a comment editor will be available in a tab."
+
+	<classAnnotation>
+	^ClyTabActivationStrategyAnnotation for: RPackage asCalypsoItemContext
 ]
 
 { #category : #activation }
-ClyPackageRichTextCommentEditorToolMorph class >> browserTabActivation2 [  
-	"Do nothing - part of a hack for overriding the class package tool in Calypso"
+ClyPackageRichTextCommentEditorToolMorph class >> browserTabActivation2 [
+	<classAnnotation>
+	
+	^ClyTabActivationStrategyAnnotation for: ClyClassGroup asCalypsoItemContext
+]
+
+{ #category : #testing }
+ClyPackageRichTextCommentEditorToolMorph class >> shouldBeActivatedInContext: aBrowserContext [
+	^aBrowserContext isPackageSelected and: [aBrowserContext isClassSelected not]
+]
+
+{ #category : #activation }
+ClyPackageRichTextCommentEditorToolMorph class >> tabOrder [
+	^ -10
+]
+
+{ #category : #operations }
+ClyPackageRichTextCommentEditorToolMorph >> applyChanges [
+
+	self pendingText asString = self editingText ifFalse: [
+		editingPackage packageManifest comment: self pendingText stamp: Author changeStamp].
+
+	^true
 ]
 
 { #category : #rendering }
@@ -41,6 +66,13 @@ ClyPackageRichTextCommentEditorToolMorph >> asRenderedText: comment [
 	^ self renderComment: comment asText asString of: self editingPackage 
 ]
 
+{ #category : #controlling }
+ClyPackageRichTextCommentEditorToolMorph >> attachToSystem [
+
+	browser system 
+		when: (ClyPackageChange of: editingPackage) send: #triggerUpdate to: self
+]
+
 { #category : #accessing }
 ClyPackageRichTextCommentEditorToolMorph >> basicEditingText [
 
@@ -53,8 +85,34 @@ ClyPackageRichTextCommentEditorToolMorph >> basicEditingText [
 ]
 
 { #category : #initialization }
+ClyPackageRichTextCommentEditorToolMorph >> defaultIconName [
+	^#comments
+]
+
+{ #category : #initialization }
+ClyPackageRichTextCommentEditorToolMorph >> defaultTitle [
+	^'Comment'
+]
+
+{ #category : #controlling }
+ClyPackageRichTextCommentEditorToolMorph >> detachFromSystem [
+
+	browser system unsubscribe: self
+]
+
+{ #category : #initialization }
 ClyPackageRichTextCommentEditorToolMorph >> disable [
 	textMorph enabled: false
+]
+
+{ #category : #accessing }
+ClyPackageRichTextCommentEditorToolMorph >> editingPackage [
+	^ editingPackage
+]
+
+{ #category : #accessing }
+ClyPackageRichTextCommentEditorToolMorph >> editingPackage: anObject [
+	editingPackage := anObject
 ]
 
 { #category : #initialization }
@@ -78,9 +136,39 @@ ClyPackageRichTextCommentEditorToolMorph >> initialize [
 
 ]
 
+{ #category : #testing }
+ClyPackageRichTextCommentEditorToolMorph >> isSimilarTo: anotherBrowserTool [
+	(super isSimilarTo: anotherBrowserTool) ifFalse: [ ^false ].
+	
+	^editingPackage = anotherBrowserTool editingPackage
+]
+
+{ #category : #accessing }
+ClyPackageRichTextCommentEditorToolMorph >> packageCommentBlank [
+
+	^'Please comment package here'
+]
+
+{ #category : #printing }
+ClyPackageRichTextCommentEditorToolMorph >> printContext [
+	^editingPackage name
+]
+
 { #category : #rendering }
 ClyPackageRichTextCommentEditorToolMorph >> setBackgroundColor: aColor [
 
 	textMorph color: aColor
 	
+]
+
+{ #category : #initialization }
+ClyPackageRichTextCommentEditorToolMorph >> setUpModelFromContext [
+	super setUpModelFromContext.
+
+	editingPackage := context lastSelectedPackage
+]
+
+{ #category : #testing }
+ClyPackageRichTextCommentEditorToolMorph >> wantsTextStyling [
+	^false
 ]

--- a/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
@@ -5,7 +5,7 @@ I need to be refactored somehow as `ClyPackageRichTextCommentEditorToolMorph` an
 "
 Class {
 	#name : #ClyRichTextClassCommentEditorToolMorph,
-	#superclass : #ClyClassCommentEditorToolMorph,
+	#superclass : #ClyClassEditorToolMorph,
 	#traits : 'TClyRichTextCommentEditorPaneMorph',
 	#classTraits : 'TClyRichTextCommentEditorPaneMorph classTrait',
 	#instVars : [
@@ -15,13 +15,21 @@ Class {
 }
 
 { #category : #activation }
-ClyRichTextClassCommentEditorToolMorph class >> classCommentTabActivation [ 
-	"Do nothing - part of a hack for overriding the class comment tool in Calypso"
+ClyRichTextClassCommentEditorToolMorph class >> classCommentTabActivation [
+	<classAnnotation>
+	
+	^ClyTabActivationStrategyAnnotation for: ClyClassComment asCalypsoItemContext
 ]
 
-{ #category : #activation }
-ClyRichTextClassCommentEditorToolMorph class >> classTabActivation [  
-	"Do nothing - part of a hack for overriding the class comment tool in Calypso"
+{ #category : #operations }
+ClyRichTextClassCommentEditorToolMorph >> applyChanges [
+
+	self pendingText asString = self editingText asString 
+		ifFalse: [ editingClass 
+						comment: self pendingText 
+						stamp: Author changeStamp].
+
+	^true
 ]
 
 { #category : #rendering }
@@ -33,9 +41,32 @@ ClyRichTextClassCommentEditorToolMorph >> asRenderedText: comment [
 	^ self renderComment: comment asText asString of: self editingClass 
 ]
 
+{ #category : #accessing }
+ClyRichTextClassCommentEditorToolMorph >> basicEditingText [
+
+	^ editingClass comment
+]
+
+{ #category : #initialization }
+ClyRichTextClassCommentEditorToolMorph >> defaultIconName [
+	^(context lastSelectedItem isMarkedWith: ClyNoCommentTag)
+		ifTrue: [ #uncommentedClass ]
+		ifFalse: [ #comments]
+]
+
+{ #category : #initialization }
+ClyRichTextClassCommentEditorToolMorph >> defaultTitle [
+	^'Comment'
+]
+
 { #category : #rendering }
 ClyRichTextClassCommentEditorToolMorph >> disable [
 	textMorph enabled: false
+]
+
+{ #category : #accessing }
+ClyRichTextClassCommentEditorToolMorph >> editingMode [
+	^ RubSmalltalkCommentMode new
 ]
 
 { #category : #rendering }
@@ -59,9 +90,30 @@ ClyRichTextClassCommentEditorToolMorph >> initialize [
 	self initializePaneTrait
 ]
 
+{ #category : #printing }
+ClyRichTextClassCommentEditorToolMorph >> printContext [
+	^super printContext , ' / ', editingClass name
+]
+
 { #category : #initialization }
 ClyRichTextClassCommentEditorToolMorph >> setBackgroundColor: aColor [
 	
 	textMorph color: aColor
 	
+]
+
+{ #category : #initialization }
+ClyRichTextClassCommentEditorToolMorph >> setUpDefaultIcon [
+	"Here we duplicate logic of #defaultIconName to directly ask class about comment.
+	This method is called during background tab building. 
+	So it does not really affect performance which is critical for remote scenario"
+	
+	| iconName |
+	iconName := editingClass hasComment ifTrue: [ #comments ] ifFalse: [ #uncommentedClass ].
+	containerTab icon: (self iconNamed: iconName)
+]
+
+{ #category : #testing }
+ClyRichTextClassCommentEditorToolMorph >> wantsTextStyling [
+	^false
 ]

--- a/src/BeautifulComments/TClyRichTextCommentEditorPaneMorph.trait.st
+++ b/src/BeautifulComments/TClyRichTextCommentEditorPaneMorph.trait.st
@@ -38,7 +38,7 @@ TClyRichTextCommentEditorPaneMorph >> editColor [
 { #category : #'trait rendering' }
 TClyRichTextCommentEditorPaneMorph >> editingText [
 	| text |
-	text := super editingText.
+	text := self basicEditingText.
 	^ isRendering 
 		ifTrue: [ self asRenderedText: text ]
 		ifFalse: [ text ]


### PR DESCRIPTION
inheritance from basic comment editor is removed and needed methods moved to the ClyRichText*Comment classes.
 basic comment editors will be removed from Pharo image in another PR