### PR TITLE
Pharo12 branch should depend on Pharo12 projects

### DIFF
--- a/src/BaselineOfBeautifulComments/BaselineOfBeautifulComments.class.st
+++ b/src/BaselineOfBeautifulComments/BaselineOfBeautifulComments.class.st
@@ -13,7 +13,7 @@ BaselineOfBeautifulComments >> baseline: spec [
 			baseline: 'Microdown'
 			with: [
 				spec
-					repository: 'github://pillar-markup/Microdown:dev/src';
+					repository: 'github://pillar-markup/Microdown:Pharo12/src';
 					loads: #('RichText') ].
 		spec 
 			package: #'BeautifulComments'  with: [


### PR DESCRIPTION
Else the wrong version end up in Pharo