### PR TITLE
Add Package>>#buildMicroDownUsing:withComment:

### DIFF
--- a/src/BeautifulComments/BaselineOf.extension.st
+++ b/src/BeautifulComments/BaselineOf.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : 'BaselineOf' }
+
+{ #category : '*BeautifulComments' }
+BaselineOf class >> buildMicroDownUsing: aBuilder withComment: aString [
+	aBuilder
+		header: [ aBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: 'A baseline is a kind of map to load project.';
+		newLine;
+		header: [ aBuilder text: 'Description' ] withLevel: 3;
+		text: aString;
+		newLine;
+		header: [ aBuilder text: 'Dependencies' ] withLevel: 3.
+
+	(self instanceSide includesLocalSelector: #baseline:) 
+		ifTrue: [ aBuilder 
+						codeblockTag: 'pharo'
+						withBody: (self instanceSide sourceCodeAt: #baseline:) ]
+]

--- a/src/BeautifulComments/Class.extension.st
+++ b/src/BeautifulComments/Class.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : 'Class' }
+
+{ #category : '*BeautifulComments' }
+Class >> buildMicroDownUsing: aBuilder withComment: aString [
+	
+	aBuilder 
+		header: [ aBuilder text: 'Class: '.
+					aBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString.
+	
+	self addDocumentSectionExampleCodeTo: aBuilder.
+	
+	self 
+		addDocumentSectionTo: aBuilder  
+		label: 'Examples' 
+		methods: (self class methods select: [ :each | each protocol = self documentExamplesProtocol ])
+]

--- a/src/BeautifulComments/Package.extension.st
+++ b/src/BeautifulComments/Package.extension.st
@@ -1,0 +1,33 @@
+Extension { #name : 'Package' }
+
+{ #category : '*BeautifulComments' }
+Package >> buildMicroDownUsing: aBuilder withComment: aString [
+	
+	"I'm on a package and the package is a baseline package."
+	self class environment
+		at: self name
+		ifPresent: [ :cls | 
+			aBuilder
+				header: [ aBuilder text: self name ] withLevel: 1;
+				horizontalLine;
+				text: 'A baseline is a kind of map to load project.';
+				newLine;
+				header: [ aBuilder text: 'Description' ] withLevel: 3;
+				text: aString;
+				newLine;
+				header: [ aBuilder text: 'Dependencies' ] withLevel: 3;
+				codeblockTag: 'pharo'
+					withBody:
+					(cls
+						sourceCodeAt: #baseline:
+						ifAbsent: [ 'No baseline! Houston we have a problem' ]) ]
+		ifAbsent: [ aBuilder
+				header: [ 
+					aBuilder
+						text: 'Package: ';
+						text: self name ]
+					withLevel: 1;
+				horizontalLine;
+				text: aString ]
+
+]

--- a/src/BeautifulComments/RGBehavior.extension.st
+++ b/src/BeautifulComments/RGBehavior.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'RGBehavior' }
+
+{ #category : '*BeautifulComments' }
+RGBehavior >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
+
+	aMicMicrodownTextualBuilder
+		header: [ aMicMicrodownTextualBuilder text: 'Class: '.
+					aMicMicrodownTextualBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString
+]

--- a/src/BeautifulComments/RGPackage.extension.st
+++ b/src/BeautifulComments/RGPackage.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'RGPackage' }
+
+{ #category : '*BeautifulComments' }
+RGPackage >> buildMicroDownUsing: aMicMicrodownTextualBuilder withComment: aString [
+
+	aMicMicrodownTextualBuilder
+		header: [ aMicMicrodownTextualBuilder text: 'Class: '.
+					aMicMicrodownTextualBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		text: aString
+]

--- a/src/BeautifulComments/TestCase.extension.st
+++ b/src/BeautifulComments/TestCase.extension.st
@@ -1,0 +1,29 @@
+Extension { #name : 'TestCase' }
+
+{ #category : '*BeautifulComments' }
+TestCase class >> buildMicroDownUsing: aBuilder withComment: aString [
+	
+	| number |
+	number := self allTestSelectors size.
+	aBuilder
+		header: [ aBuilder text: self name ] withLevel: 1;
+		horizontalLine;
+		header: [ aBuilder text: 'Description' ] withLevel: 3;
+		text: aString;
+		newLine;
+		header: [ aBuilder text: 'Tests' ] withLevel: 3;
+		text: 'This test suite '.
+	number isZero
+		ifTrue: [ ^ aBuilder text: 'has no test methods.'].
+	
+	aBuilder 
+		text: 'defines ', number asString, ' test method'.
+	number = 1
+		ifFalse: [ aBuilder text: 's'  ]. 
+	aBuilder text: ':'.
+
+	aBuilder 	
+		newLine;
+		unorderedListDuring: [ self testSelectors
+				do: [ :each | aBuilder item: [ aBuilder monospace: (self class instanceSide name , '>>#' , each) asString ] ]]
+]


### PR DESCRIPTION
Also moved the following implementations of #buildMicroDownUsing:withComment: from Microdown to BeautifulComments:

- BaselineOf
- Class
- Package
- RGBehavior
- RGPackage
- TestCase

Note I couldn't PR to Microdown to fix it there yet because of [this issue](https://github.com/pharo-vcs/iceberg/issues/1803).
