### PR TITLE
Make BaselineOfBeautifulComments for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘master’ for Microdown

### DIFF
--- a/src/BaselineOfBeautifulComments/BaselineOfBeautifulComments.class.st
+++ b/src/BaselineOfBeautifulComments/BaselineOfBeautifulComments.class.st
@@ -13,7 +13,7 @@ BaselineOfBeautifulComments >> baseline: spec [
 			baseline: 'Microdown'
 			with: [
 				spec
-					repository: 'github://pillar-markup/Microdown:master/src';
+					repository: 'github://pillar-markup/Microdown:v2.4.1/src';
 					loads: #('RichText') ].
 		spec 
 			package: #'BeautifulComments'  with: [


### PR DESCRIPTION
This pull request makes BaselineOfBeautifulComments for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘master’ for Microdown, see [Pharo issue #17391](https://github.com/pharo-project/pharo/issues/17391). I used ‘integration’ as the base branch for this pull request, that should maybe be changed to ‘Pharo11’ but that branch doesn’t exist yet.